### PR TITLE
Corrige ArgumentErrors (given 2, expected 1) e refatora :should -> :expect nos tests cases

### DIFF
--- a/hws/vcg_hw0/spec/vcg_hw0_part1_spec.rb
+++ b/hws/vcg_hw0/spec/vcg_hw0_part1_spec.rb
@@ -7,15 +7,15 @@ describe 'Ruby intro part 1' do
     end
 
     it "returns correct sum [20 points]" do
-      sum([1,2,3,4,5]).should be_a_kind_of Fixnum
-      sum([1,2,3,4,5]).should == 15
-      sum([1,2,3,4,-5]).should == 5
-      sum([1,2,3,4,-5,5,-100]).should == -90
+      expect(sum([1,2,3,4,5])).to be_a_kind_of Integer
+      expect(sum([1,2,3,4,5])).to be == 15
+      expect(sum([1,2,3,4,-5])).to be == 5
+      expect(sum([1,2,3,4,-5,5,-100])).to be == -90
     end
 
     it "works on the empty array [10 points]" do
       expect { sum([]) }.not_to raise_error
-      sum([]).should be_zero
+      expect(sum([])).to be_zero
     end
     
   end
@@ -25,17 +25,17 @@ describe 'Ruby intro part 1' do
       expect { max_2_sum([1,2,3]) }.not_to raise_error
     end
     it "returns the correct sum [7 points]" do
-      max_2_sum([1,2,3,4,5]).should be_a_kind_of Fixnum
-      max_2_sum([1,-2,-3,-4,-5]).should == -1
+      expect(max_2_sum([1,2,3,4,5])).to be_a_kind_of Integer
+      expect(max_2_sum([1,-2,-3,-4,-5])).to be == -1
     end
     it 'works even if 2 largest values are the same [3 points]' do
-      max_2_sum([1,2,3,3]).should == 6
+      expect(max_2_sum([1,2,3,3])).to be == 6
     end
     it "returns zero if array is empty [10 points]" do
-      max_2_sum([]).should be_zero
+      expect(max_2_sum([])).to be_zero
     end
     it "returns value of the element if just one element [10 points]" do
-      max_2_sum([3]).should == 3
+      expect(max_2_sum([3])).to be == 3
     end
   end
 
@@ -44,18 +44,18 @@ describe 'Ruby intro part 1' do
       expect { sum_to_n?([1,2,3],4) }.not_to raise_error
     end
     it "returns true when any two elements sum to the second argument [30 points]" do
-      sum_to_n?([1,2,3,4,5], 5).should be true
-      sum_to_n?([3,0,5], 5).should be true
-      sum_to_n?([-1,-2,3,4,5,-8], 12).should be false
-      sum_to_n?([-1,-2,3,4,6,-8], 12).should be false
+      expect(sum_to_n?([1,2,3,4,5], 5)).to be true
+      expect(sum_to_n?([3,0,5], 5)).to be true
+      expect(sum_to_n?([-1,-2,3,4,5,-8], 12)).to be false
+      expect(sum_to_n?([-1,-2,3,4,6,-8], 12)).to be false
     end
     it "returns false for the single element array [5 points]" do
-      sum_to_n?([1], 1).should be false
-      sum_to_n?([3], 0).should be false
+      expect(sum_to_n?([1], 1)).to be false
+      expect(sum_to_n?([3], 0)).to be false
     end
     it "returns false for the empty array [5 points]" do
-      sum_to_n?([], 0).should be false
-      sum_to_n?([], 7).should be false
+      expect(sum_to_n?([], 0)).to be false
+      expect(sum_to_n?([], 7)).to be false
     end
   end
 end

--- a/hws/vcg_hw0/spec/vcg_hw0_part2_spec.rb
+++ b/hws/vcg_hw0/spec/vcg_hw0_part2_spec.rb
@@ -7,10 +7,10 @@ describe "#hello" do
   end
 
   it "The hello method returns the correct string [30 points]" do
-    hello("Dan").class.should == String
-    hello("Dan").should eq('Hello, Dan'), "Incorrect results for input: \"Dan\""
-    hello("BILL").should eq('Hello, BILL'), "Incorrect results for input: \"BILL\""
-    hello("Mr. Ilson").should eq('Hello, Mr. Ilson'), "Incorrect results for input: \"Mr. Ilson\""
+    expect(hello("Dan").class).to be == String
+    expect(hello("Dan")).to eq('Hello, Dan'), "Incorrect results for input: \"Dan\""
+    expect(hello("BILL")).to eq('Hello, BILL'), "Incorrect results for input: \"BILL\""
+    expect(hello("Mr. Ilson")).to eq('Hello, Mr. Ilson'), "Incorrect results for input: \"Mr. Ilson\""
   end
 end
 
@@ -20,22 +20,22 @@ describe "#starts_with_consonant?" do
     expect { starts_with_consonant?("d") }.not_to raise_error()
   end
   it 'classifies true cases [10 points]' do
-    starts_with_consonant?('v').should be true, "'v' is a consonant"
+    expect(starts_with_consonant?('v')).to be true #, "'v' is a consonant"
     ['v', 'vest', 'Veeee', 'crypt'].each do |string|
-      starts_with_consonant?(string).should be true, "Incorrect results for input: \"#{string}\""
+      expect(starts_with_consonant?(string)).to be true #, "Incorrect results for input: \"#{string}\""
     end
   end
   it 'classifies false cases [10 points]' do
-    starts_with_consonant?('a').should be false, "'a' is not a consonant"
+    expect(starts_with_consonant?('a')).to be false #, "'a' is not a consonant"
     ['asdfgh', 'Unix'].each do |string|
-        starts_with_consonant?(string).should be false, "Incorrect results for input: \"#{string}\""
+        expect(starts_with_consonant?(string)).to be false #, "Incorrect results for input: \"#{string}\""
     end
   end
   it 'works on the empty string [5 points]' do
-    starts_with_consonant?('').should be false
+    expect(starts_with_consonant?('')).to be false
   end
   it 'works on nonletters [5 points]' do
-    starts_with_consonant?('#foo').should be false
+    expect(starts_with_consonant?('#foo')).to be false
   end
 end
 
@@ -46,14 +46,14 @@ describe "#binary_multiple_of_4?" do
   end
   it "classifies valid binary numbers [30 points]" do
     ["1010101010100", "0101010101010100", "100", "0"].each do |string|
-      binary_multiple_of_4?(string).should be true,  "Incorrect results for input: \"#{string}\""
+      expect(binary_multiple_of_4?(string)).to be true #, "Incorrect results for input: \"#{string}\""
     end
     ["101", "1000000000001"].each do |string|
-      binary_multiple_of_4?(string).should_not be true,  "Incorrect results for input: \"#{string}\""
+      expect(binary_multiple_of_4?(string)).not_to be true #, "Incorrect results for input: \"#{string}\""
     end
   end
   it "rejects invalid binary numbers [10 points]" do
-    binary_multiple_of_4?('a100').should be false, "'a100' is not a valid binary number!"
-    binary_multiple_of_4?('').should be false, "The empty string is not a valid binary number!"
+    expect(binary_multiple_of_4?('a100')).to be false #, "'a100' is not a valid binary number!"
+    expect(binary_multiple_of_4?('')).to be false #, "The empty string is not a valid binary number!"
   end
 end

--- a/hws/vcg_hw0/spec/vcg_hw0_part3_spec.rb
+++ b/hws/vcg_hw0/spec/vcg_hw0_part3_spec.rb
@@ -8,18 +8,18 @@ describe "BookInStock" do
   describe 'getters and setters' do
     before(:each)  { @book = BookInStock.new('isbn1', 33.8) }
     it 'should set ISBN [10 points]' do
-      @book.isbn.should == 'isbn1'
+      expect(@book.isbn).to be == 'isbn1'
     end
     it 'should set price [10 points]' do
-      @book.price.should == 33.8
+      expect(@book.price).to be == 33.8
     end
     it 'should be able to change ISBN [10 points]' do
       @book.isbn = 'isbn2'
-      @book.isbn.should == 'isbn2'
+      expect(@book.isbn).to be == 'isbn2'
     end
     it 'should be able to change price [10 points]' do
       @book.price = 300.0
-      @book.price.should == 300.0
+      expect(@book.price).to be == 300.0
     end
   end
   describe 'constructor' do
@@ -35,16 +35,16 @@ describe "BookInStock" do
   end
   describe "#price_as_string" do
     it "should be defined" do
-      BookInStock.new('isbn1', 10).should respond_to(:price_as_string)
+      expect(BookInStock.new('isbn1', 10)).to respond_to(:price_as_string)
     end
     it 'should display 33.95 as "$33.95" [10 points]' do
-      BookInStock.new('isbn11', 33.95).price_as_string.should == '$33.95'
+      expect(BookInStock.new('isbn11', 33.95).price_as_string).to be == '$33.95'
     end
     it "should display 1.1 as $1.10 [10 points]" do
-      BookInStock.new('isbn11', 1.1).price_as_string.should == '$1.10'
+      expect(BookInStock.new('isbn11', 1.1).price_as_string).to be == '$1.10'
     end
     it "should display 20 as $20.00 [10 points]" do
-      BookInStock.new('isbn11', 20).price_as_string.should == '$20.00'
+      expect(BookInStock.new('isbn11', 20).price_as_string).to be == '$20.00'
     end
   end
 end


### PR DESCRIPTION
## Description
Pull Request para corrigir tanto os bugs observados ao rodar os unit tests com rspec v. 3.8 quanto os deprecation warnings ao usar :should ao invés de :expect
